### PR TITLE
add header for logged in user

### DIFF
--- a/src/features/client/components/Header/index.jsx
+++ b/src/features/client/components/Header/index.jsx
@@ -10,6 +10,7 @@ import {
   Text,
 } from '@chakra-ui/react';
 import React from 'react';
+import { useState } from 'react';
 
 import { basket } from '../../mocks/basketMock';
 import logoUrl from '../../../../assets/application-logo.svg';
@@ -19,6 +20,7 @@ import LogInModal from '../LogInModal';
 
 import BasketModal from '../BasketModal';
 import SignUpModal from '../SignupModal';
+import LoggedInUserHeader from '../LoggedInUserHeader';
 
 function Header() {
   const {
@@ -31,6 +33,8 @@ function Header() {
     onOpen: onSignupModalOpen,
     onClose: onSignupModalClose,
   } = useDisclosure();
+
+  const [isLoggedIn, setIsLoggedIn] = useState(true);
 
   return (
     <>
@@ -77,19 +81,28 @@ function Header() {
             </Button>
           </Flex>
           <Box>
-            <ButtonGroup gap={{ base: '5px', sm: '20px' }}>
-              <Button onClick={onLoginModalOpen} variant="ghost">
-                Log In
-              </Button>
-              <Button
-                onClick={onSignupModalOpen}
-                colorScheme="blue"
-                color="white"
-              >
-                Sign up
-              </Button>
-            </ButtonGroup>
-            <BasketModal basket={basket} />
+            {isLoggedIn ? (
+              <Flex>
+                <LoggedInUserHeader setIsLoggedIn={setIsLoggedIn} />
+                <BasketModal basket={basket} />
+              </Flex>
+            ) : (
+              <>
+                <ButtonGroup gap={{ base: '5px', sm: '20px' }}>
+                  <Button onClick={onLoginModalOpen} variant="ghost">
+                    Log In
+                  </Button>
+                  <Button
+                    onClick={onSignupModalOpen}
+                    colorScheme="blue"
+                    color="white"
+                  >
+                    Sign up
+                  </Button>
+                </ButtonGroup>
+                <BasketModal basket={basket} />
+              </>
+            )}
           </Box>
         </Box>
         <Box

--- a/src/features/client/components/LoggedInUserHeader/index.jsx
+++ b/src/features/client/components/LoggedInUserHeader/index.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import {
+  Avatar,
+  Box,
+  Flex,
+  HStack,
+  Icon,
+  Menu,
+  MenuButton,
+  MenuDivider,
+  MenuItem,
+  MenuList,
+  Text,
+  useColorModeValue,
+  VStack,
+} from '@chakra-ui/react';
+
+import {
+  FiChevronDown,
+  FiSettings,
+  CgProfile,
+  FiLogOut,
+} from 'react-icons/all.js';
+
+function LoggedInUserHeader({ setIsLoggedIn }) {
+  return (
+    <HStack spacing={{ base: '0', md: '6' }}>
+      <Flex alignItems={'center'}>
+        <Menu>
+          <MenuButton
+            py={2}
+            transition="all 0.3s"
+            _focus={{ boxShadow: 'none' }}
+          >
+            <HStack>
+              <Avatar
+                size={'sm'}
+                src={
+                  'https://images.unsplash.com/photo-1619946794135-5bc917a27793?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&fit=crop&h=200&w=200&s=b616b2c5b373a80ffc9636ba24f7a4a9'
+                }
+              />
+              <VStack
+                display={{ base: 'none', md: 'flex' }}
+                alignItems="flex-start"
+                spacing="1px"
+                ml="2"
+              >
+                <Text fontSize="sm">Justina Clark</Text>
+              </VStack>
+              <Box display={{ base: 'none', md: 'flex' }}>
+                <FiChevronDown />
+              </Box>
+            </HStack>
+          </MenuButton>
+          <MenuList
+            bg={useColorModeValue('white', 'gray.900')}
+            borderColor={useColorModeValue('gray.200', 'gray.700')}
+          >
+            <MenuItem>
+              <Icon
+                mr="4"
+                fontSize="16"
+                _groupHover={{
+                  color: 'white',
+                }}
+                as={CgProfile}
+              />
+              Profile
+            </MenuItem>
+            <MenuItem>
+              <Icon
+                mr="4"
+                fontSize="16"
+                _groupHover={{
+                  color: 'white',
+                }}
+                as={FiSettings}
+              />
+              Settings
+            </MenuItem>
+            <MenuDivider />
+            <MenuItem onClick={() => setIsLoggedIn(false)}>
+              <Icon
+                mr="4"
+                fontSize="16"
+                _groupHover={{
+                  color: 'white',
+                }}
+                as={FiLogOut}
+              />
+              Sign out
+            </MenuItem>
+          </MenuList>
+        </Menu>
+      </Flex>
+    </HStack>
+  );
+}
+
+export default LoggedInUserHeader;


### PR DESCRIPTION
user should see it's profile picture and name when logged in
![image](https://user-images.githubusercontent.com/112716066/222229646-0a0672e5-2725-457a-9a83-815c41443f39.png)

on profile click user should see 3 menu items
![image](https://user-images.githubusercontent.com/112716066/222229896-4a9a4702-673a-4f1e-a3ec-939ea5bfdf2b.png)

**responsive design**:

on small screen user should see only it's profile picture

![image](https://user-images.githubusercontent.com/112716066/222230255-630a39e3-4552-427e-af9a-9b8ecf7b970c.png)

for now user can log out by clicking sign out button, but it's just a temporary logic using useState hook.