### PR TITLE
fix grocery merchant type categories name

### DIFF
--- a/src/constants.jsx
+++ b/src/constants.jsx
@@ -19,7 +19,7 @@ export const groceryItems = [
 
 export const merchantTypes = [
   { category: '🍝 Restaurants', value: 'restaurants' },
-  { category: '🛒 Grocery', value: 'grocery' },
+  { category: '🛒 Shops', value: 'shops' },
 ];
 
 export const paymentsMethods = ['PaySera', 'Swedbank', 'Cash'];

--- a/src/features/client/components/FilterByCategory/index.jsx
+++ b/src/features/client/components/FilterByCategory/index.jsx
@@ -13,10 +13,9 @@ function FilterByCategory({
   bgColor,
   categoryId,
   setSelectedCategory,
+  setCurrentMerchantCategory,
+  currentMerchantType,
 }) {
-  const [currentMerchantType, setCurrentMerchantCategory] =
-    useState('restaurants');
-
   const [activeCategoryIndex, setActiveCategoryIndex] = useState(0);
   const [activeMerchantTypeIndex, setActiveMerchantTypeIndex] = useState(0);
 

--- a/src/features/client/components/RestaurantList/index.jsx
+++ b/src/features/client/components/RestaurantList/index.jsx
@@ -3,7 +3,7 @@ import { Box, Flex, Heading } from '@chakra-ui/react';
 import { restaurants } from '../../mocks/restaurantsMock';
 import RestaurantListCard from '../RestaurantListCard';
 
-function RestaurantList({ isFeatured, selectedCategory }) {
+function RestaurantList({ isFeatured, selectedCategory, currentMerchantType }) {
   let restaurantsList = isFeatured
     ? restaurants.filter((item) => item.featured)
     : restaurants;
@@ -16,10 +16,10 @@ function RestaurantList({ isFeatured, selectedCategory }) {
 
   return (
     <Box as="section" className="container">
-      {selectedCategory ? (
-        <Heading>{selectedCategory} restaurants</Heading>
-      ) : (
-        <Heading>All restaurants</Heading>
+      {selectedCategory && (
+        <Heading>
+          {selectedCategory} {currentMerchantType}
+        </Heading>
       )}
       <Flex
         flexWrap="wrap"

--- a/src/features/client/pages/ClientLanding/index.jsx
+++ b/src/features/client/pages/ClientLanding/index.jsx
@@ -9,6 +9,8 @@ import { restaurantItems, groceryItems } from '../../../../constants';
 
 function ClientLanding() {
   const [selectedCategory, setSelectedCategory] = useState(null);
+  const [currentMerchantType, setCurrentMerchantCategory] =
+    useState('restaurants');
 
   return (
     <Flex as="section" flexDir="column" gap="20px" mt="50px">
@@ -17,9 +19,14 @@ function ClientLanding() {
         groceryItems={groceryItems}
         categoryId={'scroll2'}
         setSelectedCategory={setSelectedCategory}
+        setCurrentMerchantCategory={setCurrentMerchantCategory}
+        currentMerchantType={currentMerchantType}
       />
       <Discovery />
-      <RestaurantList selectedCategory={selectedCategory} />
+      <RestaurantList
+        selectedCategory={selectedCategory}
+        currentMerchantType={currentMerchantType}
+      />
     </Flex>
   );
 }


### PR DESCRIPTION
User should see merchant type "Shops" instead of "Grocery", as well as on category click user should see "[category name] shops"

![image](https://user-images.githubusercontent.com/112716066/223687235-24e77356-60b0-4c44-a7ee-87c03cc82d75.png)
